### PR TITLE
Updated for new project structure

### DIFF
--- a/genRust.go
+++ b/genRust.go
@@ -96,6 +96,7 @@ var (
 #[cfg_attr(feature = "derive_serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "derive_clone", derive(Clone))]
 #[cfg_attr(feature = "derive_partial_eq", derive(PartialEq))]
+#[cfg_attr(feature = "derive_samplify", derive(Sampleable))]
 `
 )
 
@@ -121,7 +122,9 @@ use regex::Regex;
 use crate::common::*;
 use open_payments_common::ValidationError;
 #[cfg(feature = "derive_serde")]
-use serde::{Deserialize, Serialize};`
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "derive_samplify")]
+use samplify_rs::Sampleable;`
 	source := []byte(fmt.Sprintf("%s\n\n%s", copyright, imports+gen.Field))
 	f.Write(source)
 	return err

--- a/genRust.go
+++ b/genRust.go
@@ -119,6 +119,7 @@ func (gen *CodeGenerator) GenRust() error {
 #![allow(unused_imports)]
 use regex::Regex;
 use crate::common::*;
+use open_payments_common::ValidationError;
 #[cfg(feature = "derive_serde")]
 use serde::{Deserialize, Serialize};`
 	source := []byte(fmt.Sprintf("%s\n\n%s", copyright, imports+gen.Field))

--- a/genRust.go
+++ b/genRust.go
@@ -118,8 +118,7 @@ func (gen *CodeGenerator) GenRust() error {
 	var imports = `
 #![allow(unused_imports)]
 use regex::Regex;
-use crate::common::*;
-use open_payments_common::ValidationError;
+use open_payments_common::{common::*, ValidationError};
 #[cfg(feature = "derive_serde")]
 use serde::{Deserialize, Serialize};`
 	source := []byte(fmt.Sprintf("%s\n\n%s", copyright, imports+gen.Field))

--- a/genRust.go
+++ b/genRust.go
@@ -116,6 +116,7 @@ func (gen *CodeGenerator) GenRust() error {
 	}
 	defer f.Close()
 	var imports = `
+#![allow(unused_imports)]
 use regex::Regex;
 use crate::common::*;
 #[cfg(feature = "derive_serde")]


### PR DESCRIPTION
This pull request includes several changes to the `genRust.go` file to improve the generation of Rust code. The most important changes involve adding an attribute parameter to the `genRustFieldCode` function, updating the function calls accordingly, and cleaning up redundant code in the `RustSimpleType` method.

Changes to function parameters and calls:

* Added an `attribute` parameter to the `genRustFieldCode` function and updated all function calls to include this new parameter. [[1]](diffhunk://#diff-9517f3e62157474d9b64d08ca210e4ac8a3fea4ab1cc173f93a989d8729436e2L299-R300) [[2]](diffhunk://#diff-9517f3e62157474d9b64d08ca210e4ac8a3fea4ab1cc173f93a989d8729436e2L409-R390) [[3]](diffhunk://#diff-9517f3e62157474d9b64d08ca210e4ac8a3fea4ab1cc173f93a989d8729436e2L437-R412) [[4]](diffhunk://#diff-9517f3e62157474d9b64d08ca210e4ac8a3fea4ab1cc173f93a989d8729436e2L474-R448) [[5]](diffhunk://#diff-9517f3e62157474d9b64d08ca210e4ac8a3fea4ab1cc173f93a989d8729436e2L496-R464) [[6]](diffhunk://#diff-9517f3e62157474d9b64d08ca210e4ac8a3fea4ab1cc173f93a989d8729436e2L509-R477) [[7]](diffhunk://#diff-9517f3e62157474d9b64d08ca210e4ac8a3fea4ab1cc173f93a989d8729436e2L519-R487)

Code cleanup:

* Removed redundant code in the `RustSimpleType` method, which included unnecessary return statements and condition checks.

Other improvements:

* Added `#![allow(unused_imports)]` to the imports section to prevent warnings for unused imports.
* Introduced logic to handle the `attribute` parameter in the `genRustFieldCode` function, modifying the `rename` variable when the `attribute` parameter is true.